### PR TITLE
added scipionshellcrown

### DIFF
--- a/chimera/Bundles/scipion/bundle_info.xml
+++ b/chimera/Bundles/scipion/bundle_info.xml
@@ -23,6 +23,7 @@ will be displayed without the ChimeraX- prefix.
     scipionrs: restores chimera sesion
     scipioncombine: combines two models
     scipionshell: shows the density of a 3D Map on a spherical shell of the map at a given radius
+    scipionshellcrown: shows a shell of a 3D map between two radii
     scipion: summary with all scipion related commands
   </Description>
 
@@ -38,6 +39,7 @@ will be displayed without the ChimeraX- prefix.
     <DataFile>docs/user/commands/scipionrs.html</DataFile>
     <DataFile>docs/user/commands/scipioncombine.html</DataFile>
     <DataFile>docs/user/commands/scipionshell.html</DataFile>
+    <DataFile>docs/user/commands/scipionshellcrown.html</DataFile>
     <DataFile>docs/user/commands/scipion.html</DataFile>
   </DataFiles>
 
@@ -65,6 +67,9 @@ will be displayed without the ChimeraX- prefix.
     </ChimeraXClassifier>
      <ChimeraXClassifier>ChimeraX :: Command :: scipionshell :: General ::
         shows the density of a 3D Map on a spherical shell of the map at a given radius r
+    </ChimeraXClassifier>
+     <ChimeraXClassifier>ChimeraX :: Command :: scipionshellcrown :: General ::
+        shows a shell of a 3D map between two radii
     </ChimeraXClassifier>
      <ChimeraXClassifier>ChimeraX :: Command :: scipion :: General ::
        summary with all scipion related commands </ChimeraXClassifier>

--- a/chimera/Bundles/scipion/src/api.py
+++ b/chimera/Bundles/scipion/src/api.py
@@ -40,6 +40,9 @@ class _MyAPI(BundleAPI):
         elif ci.name == "scipionshell":
             func = cmd.scipionshell
             desc = cmd.scipionshell_desc
+        elif ci.name == "scipionshellcrown":
+            func = cmd.scipionshellcrown
+            desc = cmd.scipionshellcrown_desc
         elif ci.name == "scipion":
             func = cmd.scipion
             desc = cmd.scipion_desc

--- a/chimera/Bundles/scipion/src/cmd.py
+++ b/chimera/Bundles/scipion/src/cmd.py
@@ -52,7 +52,7 @@ def scipionshellcrown(session,
     # very likely divisions is irrelevant here
     command = "shape icosahedron " \
               "radius %s " \
-              "divisions 2000 " \ 
+              "divisions 2000 " \
               "orientation %s " \
               "sphereFactor %s" % (sphereRadius,
                                    orientation,

--- a/chimera/Bundles/scipion/src/cmd.py
+++ b/chimera/Bundles/scipion/src/cmd.py
@@ -19,6 +19,83 @@ import ntpath
 def getConfig(session, key):
         return os.environ.get(key, False)
 
+
+def scipionshellcrown(session,
+                 model=None,
+                 sphereRadius=None,
+                 orientation='222r',
+                 sphereFactor='1',
+                 modelid=None,
+                 crownwidth=10):
+
+    """ Shows a shell of a 3D Map at radius sphereRadius
+    and with width=width
+
+    :param session:  chimera session
+    :param model: 3D map to be analyzed
+    :param sphereRadius: 3D density obtained at this radius
+    :param orientation: virus symmetry, i.e: 222, 222r, etc.
+    :param sphereFactor: allows generating a shape that is an
+    interpolation between an icosahedron and a sphere of equal radius.
+    :param modelid: output model_id. keep always the same value to
+     overwrite the previous surface.
+    :param crownwidth: shell width
+    :return: none
+    example: scipionshellcrown #1 220  10  orientation 222r   sphereFactor 1 crownwidth 60
+
+    """
+    # set model style as surface
+    mapModelId = model[0].id_string # model is a tuple, id = 1
+    command = "volume #%s style surface " % (mapModelId)
+    run(session, command)
+
+    # very likely divisions is irrelevant here
+    command = "shape icosahedron " \
+              "radius %s " \
+              "divisions 2000 " \ 
+              "orientation %s " \
+              "sphereFactor %s" % (sphereRadius,
+                                   orientation,
+                                   sphereFactor)
+    outIcosahedronId = run(session, command).id_string # id = 2
+
+    # delete output model
+    command = "close #%s;" % modelid
+    run(session, command)
+
+    # mask  in icosahedron
+    command = "volume mask #%s surfaces #%s " \
+              "fullMap true modelId %s slab %s" % \
+              (mapModelId, outIcosahedronId, modelid, crownwidth) # model id
+    run(session, command)
+
+    command = "color #%s gray all; " \
+              "lighting soft; " \
+              "cofr coordinateSystem #%s; " \
+              "lighting shadows true; " \
+              'ui tool show "Side View"' \
+              % (modelid, modelid)
+    run(session, command)
+
+    command = 'hide #%s;' \
+              'close #%s' \
+              %(mapModelId,
+                outIcosahedronId)
+    run(session, command)
+
+scipionshellcrown_desc = CmdDesc(
+    required=[('model', TopModelsArg),
+              ('sphereRadius', StringArg),
+              ('modelid', StringArg)
+              ],
+    optional= [
+               ('orientation', StringArg),
+               ('sphereFactor', StringArg),
+               ('crownwidth', StringArg),
+               ]
+)
+
+
 def scipionshell(session,
                  model=None,
                  sphereRadius=None,
@@ -31,8 +108,6 @@ def scipionshell(session,
 
     :param session:  chimera session
     :param model: 3D map to be analized
-    :param colorRadius: max and minimum values used by the colormap
-    will be taken at this radius.
     :param sphereRadius: 3D density optained at this radius
     :param orientation: virus symmetry, i.e: 222, 222r, etc.
     :param sphereFactor: allows generating a shape that is an
@@ -241,6 +316,7 @@ def scipion(session):
     scipionrs: restores chimera sesion
     scipioncombine: combines two models
     scipionshell: shows the density of a 3D Map on a spherical shell of the map at a given radius
+    scipionshellcrown: cut a shell from a 3D Map at a given radius
     
-    type "help commandname" for more information
+    type "help command_name" for more information
 """)

--- a/chimera/Bundles/scipion/src/docs/user/commands/scipion.html
+++ b/chimera/Bundles/scipion/src/docs/user/commands/scipion.html
@@ -23,6 +23,7 @@ The scipion command list all the plugins developed
   <li><a href="scipioncombine.html">scipioncombine</a>: combines two models.</li>
   <li><a href="scipionrs.html">scipionrs</a>: restores chimera session.</li>
   <li><a href="scipionshell.html">scipionshell</a>: shows the density of a 3D Map on a spherical shell of the map at a given radius.</li>
+  <li><a href="scipionshellcrown.html">scipionshellcrown</a>: cuts a shell from a 3D map at a given radius.</li>
   <li><a href="scipionss.html">scipionss</a>: saves chimera session.</li>
   <li><a href="scipionwrite.html">scipionwrite</a>: writes model to disk.</li>
  </ul>

--- a/chimera/Bundles/scipion/src/docs/user/commands/scipionshell.html
+++ b/chimera/Bundles/scipion/src/docs/user/commands/scipionshell.html
@@ -1,6 +1,6 @@
 <html><head>
 <link rel="stylesheet" type="text/css" href="../userdocs.css" />
-<title>Command: scipioncombine</title>
+<title>Command: scipionshell</title>
 </head><body>
 
 <a name="top"></a>
@@ -49,6 +49,8 @@ Remark
         of <b>Map Coordinates</b> menu.</li>
     <li>Although <b>orthoplanes</b> is the visualization option by default, you can select <b>plane</b> instead in the
 <b>Volume Viewer</b> menu to see only the transversal plane.</li>
+      <li> The plane/orthoplanes can be moved using the right
+          mouse button</li>
   </ul>
 
 </p>

--- a/chimera/Bundles/scipion/src/docs/user/commands/scipionshell.html
+++ b/chimera/Bundles/scipion/src/docs/user/commands/scipionshell.html
@@ -23,7 +23,7 @@ The command  <b>scipionshell</b> shows the density of a
 where
  <ul>
   <li><bf>modelId:</bf> model id of the 3D map to be analyzed</li>
-  <li><bf>radius:</bf> radius at which the density is going to be shown</li>
+  <li><bf>radius:</bf> radius at which the density is going to be shown (pixels)</li>
   <li><bf>outModelId:</bf> id of the output icosahedron showing the density surface</li>
   <li><bf>orientation:</bf> symmetry used to create the icosahedron used to define the surface to be shown</li>
   <li><bf>sphereFactor:</bf> weight of the sphere component in an interpolation between an icosahedron and a sphere of equal radius (1.0: sphere; 0.0: icosahedron)</li>

--- a/chimera/Bundles/scipion/src/docs/user/commands/scipionshell.html
+++ b/chimera/Bundles/scipion/src/docs/user/commands/scipionshell.html
@@ -23,7 +23,7 @@ The command  <b>scipionshell</b> shows the density of a
 where
  <ul>
   <li><bf>modelId:</bf> model id of the 3D map to be analyzed</li>
-  <li><bf>radius:</bf> radius at which the density is going to be shown (pixels)</li>
+  <li><bf>radius:</bf> radius at which the density is going to be shown (Angstroms)</li>
   <li><bf>outModelId:</bf> id of the output icosahedron showing the density surface</li>
   <li><bf>orientation:</bf> symmetry used to create the icosahedron used to define the surface to be shown</li>
   <li><bf>sphereFactor:</bf> weight of the sphere component in an interpolation between an icosahedron and a sphere of equal radius (1.0: sphere; 0.0: icosahedron)</li>

--- a/chimera/Bundles/scipion/src/docs/user/commands/scipionshellcrown.html
+++ b/chimera/Bundles/scipion/src/docs/user/commands/scipionshellcrown.html
@@ -23,11 +23,11 @@ The command  <b>scipionshellcrown</b> creates a crown from a
 where
  <ul>
   <li><bf>modelId:</bf> model id of the 3D map to be analyzed</li>
-  <li><bf>radius:</bf> radius at which the density is going to be shown</li>
+  <li><bf>radius:</bf> radius at which the density is going to be shown (pixels)</li>
   <li><bf>outModelId:</bf> id of the output icosahedron showing the density surface</li>
   <li><bf>orientation:</bf> symmetry used to create the icosahedron used to define the surface to be shown (default 222r)</li>
   <li><bf>sphereFactor:</bf> weight of the sphere component in an interpolation between an icosahedron and a sphere of equal radius (1.0: sphere; 0.0: icosahedron) (default=1)</li>
-  <li><bf>crownwidth:</bf> shell width (default=10A)</li>
+  <li><bf>crownwidth:</bf> shell width (default = 10A, the crown goes from the selected radius minus 10A to the selected radius)</li>
  </ul>
 </p>
 

--- a/chimera/Bundles/scipion/src/docs/user/commands/scipionshellcrown.html
+++ b/chimera/Bundles/scipion/src/docs/user/commands/scipionshellcrown.html
@@ -27,7 +27,7 @@ where
   <li><bf>outModelId:</bf> id of the output icosahedron showing the density surface</li>
   <li><bf>orientation:</bf> symmetry used to create the icosahedron used to define the surface to be shown (default 222r)</li>
   <li><bf>sphereFactor:</bf> weight of the sphere component in an interpolation between an icosahedron and a sphere of equal radius (1.0: sphere; 0.0: icosahedron) (default=1)</li>
-  <li><bf>crownwidth:</bf> shell width (default = 10A, the crown goes from the selected radius to the selected radius plus 10A)</li>
+  <li><bf>crownwidth:</bf> shell width (default = 10A, the crown goes from the selected_radius - crownwidth/2 to  selected_radius + crownwidth/2)</li>
  </ul>
 </p>
 

--- a/chimera/Bundles/scipion/src/docs/user/commands/scipionshellcrown.html
+++ b/chimera/Bundles/scipion/src/docs/user/commands/scipionshellcrown.html
@@ -1,0 +1,64 @@
+<html><head>
+<link rel="stylesheet" type="text/css" href="../userdocs.css" />
+<title>Command: scipionshellcrown</title>
+</head><body>
+
+<a name="top"></a>
+<a href="../index.html">
+<img width="60px" src="../ChimeraX-docs-icon.svg" alt="ChimeraX docs icon"
+class="clRight" title="User Guide Index"/></a>
+
+<h3><a href="../index.html#commands">Command</a>: scipionshellcrown</h3>
+<h3 class="usage"><a href="usageconventions.html">Usage</a>:
+<br>
+    <b>scipionshellcrown modelId radius outModelId orientation XX   sphereFactor YY crownwidth ZZ</b>
+</h3>
+
+<p> 
+The command  <b>scipionshellcrown</b> creates a crown from a
+    3D Map using a a quasy-spherical shell.
+
+</p>
+<p>
+where
+ <ul>
+  <li><bf>modelId:</bf> model id of the 3D map to be analyzed</li>
+  <li><bf>radius:</bf> radius at which the density is going to be shown</li>
+  <li><bf>outModelId:</bf> id of the output icosahedron showing the density surface</li>
+  <li><bf>orientation:</bf> symmetry used to create the icosahedron used to define the surface to be shown (default 222r)</li>
+  <li><bf>sphereFactor:</bf> weight of the sphere component in an interpolation between an icosahedron and a sphere of equal radius (1.0: sphere; 0.0: icosahedron) (default=1)</li>
+  <li><bf>crownwidth:</bf> shell width (default=10A)</li>
+ </ul>
+</p>
+
+
+<h3>
+    Examples
+</h3>
+    <blockquote>
+    <b>scipionshellcrown #1 250  10 orientation 222r sphereFactor 0.7 crownwidth 5</b>
+    </blockquote>
+
+    will create a3D map with a shell pf thickness 5A of the model #1.
+The outher shell is defined by spherical icosahedron with symmetry 222r and sphereFactor 0.7.
+The model id of the output will be 10.
+
+<h3>
+Remark
+</h3>
+  <ul>
+    <li>In case the 3D map and the icosahedron do not fit, select <b>center</b> in <b>Origin index</b>
+        of <b>Map Coordinates</b> menu.</li>
+    <li>Although <b>orthoplanes</b> is the visualization option
+        by default, you can select <b>plane</b> instead in the
+<b>Volume Viewer</b> menu to see only the transversal plane.</li>
+      <li> The plane/orthoplanes can be moved using the right
+          mouse button</li>
+  </ul>
+
+</p>
+
+<hr>
+<address>scipion@cnb.csic.es</address>
+</body>
+</html>

--- a/chimera/Bundles/scipion/src/docs/user/commands/scipionshellcrown.html
+++ b/chimera/Bundles/scipion/src/docs/user/commands/scipionshellcrown.html
@@ -23,11 +23,11 @@ The command  <b>scipionshellcrown</b> creates a crown from a
 where
  <ul>
   <li><bf>modelId:</bf> model id of the 3D map to be analyzed</li>
-  <li><bf>radius:</bf> radius at which the density is going to be shown (pixels)</li>
+  <li><bf>radius:</bf> radius at which the density is going to be shown (Angstroms)</li>
   <li><bf>outModelId:</bf> id of the output icosahedron showing the density surface</li>
   <li><bf>orientation:</bf> symmetry used to create the icosahedron used to define the surface to be shown (default 222r)</li>
   <li><bf>sphereFactor:</bf> weight of the sphere component in an interpolation between an icosahedron and a sphere of equal radius (1.0: sphere; 0.0: icosahedron) (default=1)</li>
-  <li><bf>crownwidth:</bf> shell width (default = 10A, the crown goes from the selected radius minus 10A to the selected radius)</li>
+  <li><bf>crownwidth:</bf> shell width (default = 10A, the crown goes from the selected radius to the selected radius plus 10A)</li>
  </ul>
 </p>
 

--- a/chimera/protocols/protocol_contacts.py
+++ b/chimera/protocols/protocol_contacts.py
@@ -119,7 +119,7 @@ class ChimeraProtContacts(EMProtocol):
                             "default contact rule: -0.4 (from 0.0 to -1.0)\n"
                             "default clash rule: 0.6 (from 0.4 to 1.0)\n"
                             'More information: \n'
-                            'https://www.cgl.ucsf.edu/chimera/current/docs/UsersGuide/midas/findclash.html'
+                            'https://www.cgl.ucsf.edu/chimerax/docs/user/commands/clashes.html#top'
                        )
         group.addParam('allowance', FloatParam,
                        label="allowance (Angstroms): ", default=0.0,
@@ -127,7 +127,7 @@ class ChimeraProtContacts(EMProtocol):
                        help="default contact rule: 0.0\n"
                             "default clash rule: 0.4\n"
                             'More information: \n'
-                            'https://www.cgl.ucsf.edu/chimera/current/docs/UsersGuide/midas/findclash.html'
+                            'https://www.cgl.ucsf.edu/chimerax/docs/user/commands/clashes.html#top'
                        )
         form.addLine('')
 


### PR DESCRIPTION
added option scipionshellcrown to chimera "bundle". This option  creates a crown (shell) of a given width. Example

    example: scipionshellcrown #1 220  10  orientation 222r   sphereFactor 1 crownwidth 60

will create a  shell at radius 220 with width 60 using as base surface an icosahedron oriented as "222r" and with spherefactor 1.