### PR TITLE
Version changed from 3.3.4 to 3.3.5. 

### DIFF
--- a/chimera/__init__.py
+++ b/chimera/__init__.py
@@ -31,7 +31,7 @@ from glob import glob
 from .constants import (CHIMERA_HOME, ALPHAFOLD_HOME, ALPHAFOLD_DATABASE_DIR, 
                         V1_0, V1_1, V1_2_5, V1_3, V1_4, chimeraTARs)
 
-__version__ = "3.3.4"
+__version__ = "3.3.5"
 _logo = "chimerax_logo.png"
 _references = ['Goddard2018']
 


### PR DESCRIPTION
Modifications in restore session protocol and test modeller search according to new biopython version concerning alphabets, after devel master branch can be updated.

tests running without errors:

scipion3 tests chimera.tests.test_protocol_modeller_search.TestChimeraModellerSearch;
scipion3 tests chimera.tests.test_protocol_chimera_operate.TestChimeraOperate;
scipion3 tests chimera.tests.test_protocol_chimera_map_subtraction.TestChimeraSubtractMap;
scipion3 tests chimera.tests.test_protocol_chimera_fit.TestChimeraFit2;
scipion3 tests chimera.tests.test_objects.TestPAE;
scipion3 tests chimera.tests.test_alpha_fold.TestChimeraAlphafoldImport;
scipion3 tests chimera.tests.test_protocol_contact.TestChimeraContact
