### PR TITLE
Replaced chimeraScriptFileName for chimeraPythonFileName

### DIFF
--- a/chimera/protocols/protocol_alphafold.py
+++ b/chimera/protocols/protocol_alphafold.py
@@ -43,7 +43,11 @@ from pwem.convert import AtomicStructHandler
 import pwem.objects as emobj
 
 from pwem.protocols import EMProtocol
-from pwem.viewers.viewer_chimera import chimeraScriptFileName, Chimera
+try: # TODO: TO REMOVE when pwem updated
+    from pwem.viewers.viewer_chimera import chimeraPythonFileName
+except:
+    chimeraPythonFileName = "chimeraPythonScript.py"
+from pwem.viewers.viewer_chimera import Chimera
 from chimera import Plugin
 from chimera.utils import getEnvDictionary
 from pwem.convert import AtomicStructHandler
@@ -458,8 +462,8 @@ cd {ALPHAFOLD_HOME}
         Chimera.createCoordinateAxisFile(dim,
                                          bildFileName=tmpFileName,
                                          sampling=sampling)
-        chimeraScriptFileName = "chimeraPythonScript.py"
-        f = open(self._getTmpPath(chimeraScriptFileName), "w")
+        
+        f = open(self._getTmpPath(chimeraPythonFileName), "w")
         f.write('from chimerax.core.commands import run\n')
 
         f.write("run(session, 'open %s')\n" % tmpFileName)
@@ -476,14 +480,14 @@ session.logger.error('''{msg}''')
 """)
         
         # run the script:
-        _chimeraScriptFileName = os.path.abspath(
-            self._getTmpPath(chimeraScriptFileName))
+        _chimeraPythonFileName = os.path.abspath(
+            self._getTmpPath(chimeraPythonFileName))
         if len(self.extraCommands.get()) > 2:
             # TODO: parse extra command
             f.write(self.extraCommands.get())
-            args = " --nogui " + _chimeraScriptFileName
+            args = " --nogui " + _chimeraPythonFileName
         else:
-            args = " " + _chimeraScriptFileName
+            args = " " + _chimeraPythonFileName
         f.close()
 
         self._log.info('Launching: ' + Plugin.getProgram() + ' ' + args)

--- a/chimera/protocols/protocol_subtraction_maps.py
+++ b/chimera/protocols/protocol_subtraction_maps.py
@@ -49,7 +49,11 @@ from pwem.constants import (SYM_DIHEDRAL_X)
 from ..constants import (CHIMERA_SYM_NAME, CHIMERA_I222r)
 from ..convert import CHIMERA_LIST
 from pwem.protocols import EMProtocol
-from pwem.viewers.viewer_chimera import Chimera, chimeraScriptFileName
+try: # TODO: TO REMOVE when pwem updated
+    from pwem.viewers.viewer_chimera import chimeraPythonFileName
+except:
+    chimeraPytonFileName = "chimeraPythonScript.py"
+from pwem.viewers.viewer_chimera import Chimera
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 from chimera import Plugin
 from pyworkflow.utils.properties import Message
@@ -294,7 +298,7 @@ class ChimeraSubtractionMaps(EMProtocol):
 
         # building script file including the coordinate axes and the input
         # volume with samplingRate and Origin information
-        f = open(self._getTmpPath(chimeraScriptFileName), "w")
+        f = open(self._getTmpPath(chimeraPythonFileName), "w")
         f.write("from chimerax.core.commands import run\n")
 
         # building coordinate axes
@@ -559,10 +563,10 @@ class ChimeraSubtractionMaps(EMProtocol):
         if len(self.extraCommands.get()) > 2:
             f.write(self.extraCommands.get())
             args = " --nogui --script " + \
-                   os.path.abspath(self._getTmpPath(chimeraScriptFileName))
+                   os.path.abspath(self._getTmpPath(chimeraPythonFileName))
         else:
             args = " --script " + \
-                   os.path.abspath(self._getTmpPath(chimeraScriptFileName))
+                   os.path.abspath(self._getTmpPath(chimeraPythonFileName))
         f.close()
 
         self._log.info('Launching: ' + Plugin.getProgram() + ' ' + args)


### PR DESCRIPTION
Since chimeraX version has been updated to 1.6 the following change was needed:

All scripts using python commands must ending the file name in .py