### PR TITLE
convert biopython class to str before calluing scipion

### DIFF
--- a/chimera/protocols/protocol_modeller_search.py
+++ b/chimera/protocols/protocol_modeller_search.py
@@ -488,7 +488,7 @@ class ChimeraModelFromTemplate(ChimeraProtBase):
                 else:
                     cline = alignMuscleSequences(inFile, outFile)
                 args = ''
-                self.runJob(cline, args)
+                self.runJob(str(cline), args)
         elif addSeq == 1:
             # if there are additional sequences imported by the user
             if inputSeqAlign is not None:


### PR DESCRIPTION
in line

     cline = alignClustalSequences(inFile, outFile)

file protocol_modeller_search.py

    alignClustalSequences  is a biopython function that returns a biopython object. It should be converted to str before passing it to scipion command line handeler

   